### PR TITLE
Add Review Spartan to Third-party services

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [Datadog](https://www.datadoghq.com/blog/collaborate-share-track-performance-slack-datadog/) - Send notifications to slack when alerts trigger, and share graphs with your colleagues in chat.
 - [Drupal](https://www.drupal.org/project/slack) - Send messages from a Drupal website to Slack
 - [Graylog2](https://github.com/Graylog2/graylog-plugin-slack) - Send log alerts to Slack
+- [Review Spartan](https://reviewspartan.com) - Get scheduled code review reminder messages to reduce PR turn-around time
 - [Slack Message Builder](http://davestevens.github.io/slack-message-builder/) - A tool for previewing how JSON payloads translate to Slack messages
 - [Slack Slash Commands as a Service](https://sscaas.eu/) - Useful tools and API integrations through slash commands.
 - [Slacker](http://slacker.nathanhoad.net/) - Post funny replies to Slack as your favourite character


### PR DESCRIPTION
https://reviewspartan.com is a SaaS offering that helps keep development teams on-track and on-schedule by sending automated, scheduled code review reminder messages.

---

I am the sole owner of the Review Spartan service.
If I should change up the description at all to better suit this curated list please let me know!