### PR TITLE
Add blockkit python library

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@
 ### Python
 
 - [asterisk-slack](https://github.com/firehooper/asterisk-slack) - Publishes Asterisk call information to Slack
+- [blockkit-slack](https://github.com/oneor0/blockkit-slack) - A fast way to build Block Kit interfaces in Python
 - [butterfield](https://github.com/sunlightlabs/butterfield) - Python Slack bot framework using asyncio and Slack's RTM API
 - [changetip-slack](https://github.com/changecoin/changetip-slack) - ChangeTip Slack Tip bot
 - [django-slack](https://github.com/lamby/django-slack) - Slack integration for Django, using the templating engine to generate messages


### PR DESCRIPTION
I made a python library that helps building Block Kit interfaces. Our team has been successfully using it in production for the last couple of months. Maybe someone will find it useful.