### PR TITLE
Add BuildPulse for notifications of flaky tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 
 ## Third-party services
 - [Atlassian Stash](https://marketplace.atlassian.com/plugins/be.foreach.stash.notifier/server/overview) - Send notifications to a Slack channel when a repo push occurs
+- [BuildPulse](https://buildpulse.io/integrations/slack) - Get daily reports on your flakiest tests, right in Slack, for the whole team to see.
 - [Datadog](https://www.datadoghq.com/blog/collaborate-share-track-performance-slack-datadog/) - Send notifications to slack when alerts trigger, and share graphs with your colleagues in chat.
 - [Drupal](https://www.drupal.org/project/slack) - Send messages from a Drupal website to Slack
 - [Graylog2](https://github.com/Graylog2/graylog-plugin-slack) - Send log alerts to Slack


### PR DESCRIPTION
👋 Thanks for curating this list. This pull request adds the [BuildPulse](https://buildpulse.io) Slack app for dev teams to get daily reports of their flakiest tests.
