### PR TITLE
Add botlint-slack to JavaScript/TypeScript libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ An avid Slack user? A developer looking for awesome tools to build out an integr
 - [jsx-slack](https://github.com/yhatt/jsx-slack) - Build JSON object for Slack Block Kit surfaces from JSX
 - [node-slack-sdk](https://github.com/slackapi/node-slack-sdk) - Slack's official SDK for Node.js 
 - [slack-block-builder](https://github.com/raycharius/slack-block-builder) - Lightweight Node.js library for building Slack Block Kit UIs, with a declarative syntax inspired by SwiftUI
+- [botlint-slack](https://github.com/markkenangray-ui/botlint) - Block Kit validator and mock Slack client for unit testing Slack bots without real API calls.
 
 ### PHP
 


### PR DESCRIPTION
botlint-slack provides offline Block Kit validation and a mock Slack client for unit testing Slack bots without real API calls.

Fills the gap left by Slack's archived Steno tool. Zero runtime dependencies, works with Jest or Mocha.

npm: https://www.npmjs.com/package/botlint-slack