### PR TITLE
Add Fantastic Slack Channels — searchable Slack community directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An avid Slack user? A developer looking for awesome tools to build out an integr
 - [Community-Built Libraries](https://api.slack.com/community) - Slack-curated list of community open-source libraries
 - [Slack App Directory](https://slack.com/apps) - Official directory of publicly available Slack apps 
 - [Slack Emojis](https://emoji.gg) - Unofficial directory of custom emojis for Slack
+- [Fantastic Slack Channels](https://github.com/glitch-spark/fantastic-slack-channels) - Searchable directory of 425+ Slack communities for startup founders, indie makers, and developers ([browse online](https://glitch-spark.github.io/fantastic-slack-channels/))
 
 ## :art: &nbsp; Themes
 


### PR DESCRIPTION
## Summary

Adds [Fantastic Slack Channels](https://github.com/glitch-spark/fantastic-slack-channels), a merged directory of 425+ Slack communities for founders and developers with a searchable GitHub Pages site.

- Merges ReportChef Slack list + awesome-founder-communities
- Organized by startups, programming, DevOps, growth, regional
- Searchable at https://glitch-spark.github.io/fantastic-slack-channels/

Made with [Cursor](https://cursor.com)