### PR TITLE
Add wanguard-notify to Python integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ An avid Slack user? A developer looking for awesome tools to build out an integr
 - [slackbot](https://github.com/lins05/slackbot) - A chat bot for Slack
 - [slacker-cli](https://github.com/juanpabloaj/slacker-cli) - Messages to slack from the command line
 - [tasks-app](https://github.com/slackapi/tasks-app) - Simple task management app produced by Slack
+- [wanguard-notify](https://github.com/Flowtriq/wanguard-notify) - Alert bridge that forwards Andrisoft Wanguard DDoS notifications to Slack, Discord, PagerDuty, Telegram, Teams, email, and webhooks.
 - [wee-slack](https://github.com/rawdigits/wee-slack) - A WeeChat plugin for Slack
 
 ### Ruby


### PR DESCRIPTION
## What

Adds [wanguard-notify](https://github.com/Flowtriq/wanguard-notify) to the Python section of Open-Source Slack Apps and Integrations.

## About the project

`wanguard-notify` is an MIT-licensed Python script (no external dependencies, Python 3.8+) that acts as an alert bridge between Andrisoft Wanguard's DDoS detection platform and modern notification channels including Slack, Discord, PagerDuty, Telegram, Microsoft Teams, email, and generic webhooks.

Wanguard's built-in alerting is limited to email/SNMP/custom scripts. This fills the gap for teams who route alerts through Slack.